### PR TITLE
Add an empty database instead of disabling the tab when no Trigger is defined for a flow #5246

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,65 +1,55 @@
 volumes:
-  postgres-data:
-    driver: local
   kestra-data:
     driver: local
 
 services:
-  postgres:
-    image: postgres
-    volumes:
-      - postgres-data:/var/lib/postgresql/data
-    environment:
-      POSTGRES_DB: kestra
-      POSTGRES_USER: kestra
-      POSTGRES_PASSWORD: k3str4
-    healthcheck:
-      test: ["CMD-SHELL", "pg_isready -d $${POSTGRES_DB} -U $${POSTGRES_USER}"]
-      interval: 30s
-      timeout: 10s
-      retries: 10
-
   kestra:
-    image: kestra/kestra:latest
+    image: kestra/kestra:develop
     pull_policy: always
-    # Note that this setup with a root user is intended for development purpose.
-    # Our base image runs without root, but the Docker Compose implementation needs root to access the Docker socket
-    # To run Kestra in a rootless mode in production, see: https://kestra.io/docs/installation/podman-compose
+    entrypoint: /bin/bash
+    # Note that this is meant for development only. Refer to the documentation for production deployments of Kestra which runs without a root user.
     user: "root"
-    command: server standalone
+    command:
+      - -c
+      - /app/kestra server standalone --worker-thread=128
     volumes:
       - kestra-data:/app/storage
       - /var/run/docker.sock:/var/run/docker.sock
       - /tmp/kestra-wd:/tmp/kestra-wd
     environment:
       KESTRA_CONFIGURATION: |
+        micronaut: 
+          server:
+            cors:
+              enabled: true
+              configurations:
+                all:
+                  allowedOrigins:
+                    - http://localhost:5173
         datasources:
-          postgres:
-            url: jdbc:postgresql://postgres:5432/kestra
-            driverClassName: org.postgresql.Driver
-            username: kestra
-            password: k3str4
+          h2:
+            url: jdbc:h2:mem:public;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+            username: sa
+            password: ""
+            driverClassName: org.h2.Driver
         kestra:
           server:
             basic-auth:
               enabled: false
               username: "admin@kestra.io" # it must be a valid email address
               password: kestra
+          queue:
+            type: h2
           repository:
-            type: postgres
+            type: h2
           storage:
             type: local
             local:
               base-path: "/app/storage"
-          queue:
-            type: postgres
           tasks:
             tmp-dir:
               path: /tmp/kestra-wd/tmp
           url: http://localhost:8080/
     ports:
-      - "8080:8080"
-      - "8081:8081"
-    depends_on:
-      postgres:
-        condition: service_started
+      - "8085:8080"
+      - "8086:8081"

--- a/ui/src/components/flows/FlowRoot.vue
+++ b/ui/src/components/flows/FlowRoot.vue
@@ -201,7 +201,6 @@
                         name: "triggers",
                         component: FlowTriggers,
                         title: this.$t("triggers"),
-                        disabled: !this.flow.triggers,
                     });
                 }
 

--- a/ui/src/components/flows/FlowTriggers.vue
+++ b/ui/src/components/flows/FlowTriggers.vue
@@ -218,7 +218,7 @@
     import Id from "../Id.vue";
     import TriggerAvatar from "./TriggerAvatar.vue";
 </script>
-
+<!-- fair game -->
 <script>
     import Markdown from "../layout/Markdown.vue";
     import {mapGetters, mapState} from "vuex";
@@ -270,6 +270,7 @@
                 return this.flow.triggers.find(trigger => trigger.id === this.triggerId);
             },
             triggersWithType() {
+                if (this.flow.trigger === undefined) return;
                 let flowTriggers = this.flow.triggers.map(trigger => {
                     return {...trigger, sourceDisabled: trigger.disabled ?? false}
                 })
@@ -290,6 +291,7 @@
                 return this.user.isAllowed(permission.EXECUTION, action ? action : action.READ, this.flow.namespace);
             },
             loadData() {
+                if (!this.trigger) return;
                 this.$store
                     .dispatch("trigger/find", {namespace: this.flow.namespace, flowId: this.flow.id, size: this.triggersWithType.length})
                     .then(triggers => this.triggers = triggers.results);

--- a/ui/src/components/flows/TriggerFlow.vue
+++ b/ui/src/components/flows/TriggerFlow.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="trigger-flow-wrapper">
+    <div class="trigger-flow-wrapper" v-if="flow">
         <el-button id="execute-button" :class="{'onboarding-glow': guidedProperties.tourStarted}" :icon="icon.Flash" :type="type" :disabled="isDisabled()" @click="onClick()">
             {{ $t("execute") }}
         </el-button>
@@ -45,6 +45,12 @@
                 </el-form-item>
             </el-form>
         </el-dialog>
+    </div>
+
+    <div v-else class="d-flex flex-grow-1 flex-column align-items-center justify-content-center">
+        <img src="../../../src/assets/no_concurrency.svg" alt="No Triggers" class="img-size my-3">
+        <h4>Your flow doesn't have any Triggers</h4>
+        <span v-html="$t('concurrency-view.desc_no_limit')" />
     </div>
 </template>
 
@@ -144,6 +150,7 @@
                 this.localNamespace = undefined;
             },
             beforeClose(done){
+                if (!this.trigger) return;
                 if(this.guidedProperties.tourStarted) return;
 
                 this.reset();


### PR DESCRIPTION
## What changes are being made and why?

<!-- Please include a brief summary of the changes included in this PR e.g. closes #1234. -->

The changes made allow users to access "Trigger" from the Flow without using triggers. This changes it so that the user can still access the tab and see no data
---

### Before and After:
- Before
![before](https://github.com/user-attachments/assets/9750afa9-df21-475e-b2a0-d81ae3903193)
- After
![after](https://github.com/user-attachments/assets/50852120-0231-48fb-88f4-a135858d1a9d)


### Testing Instructions

1. Run `docker-compose up`
2. Run `npm run dev`
3. Access the 'flows' tab
4. Observe the behaviour