### PR TITLE
Fix for Issue #5568 - Trigger Information

### DIFF
--- a/ui/cypress/e2e/triggersAdminInfo.cy.js
+++ b/ui/cypress/e2e/triggersAdminInfo.cy.js
@@ -1,0 +1,50 @@
+describe("Trigger Admin Information Tests", () => {
+    it("Check that the flow provides information", () => {
+        cy.viewport(1920, 1080);
+        Cypress.on('uncaught:exception', (err, runnable) => {return false})
+        cy.visit("http://localhost:5173/flows");
+        cy.contains("span", "Create").click();
+        cy.wait(2000);
+        cy.url().should('include', '/flows/new');
+        cy.get('span.mtk22').first().click()
+            .type('{selectall}{backspace} ')
+        cy.get('div.view-line').children().children().click().type(`id: myflow
+namespace: company.team
+tasks:
+- id: start_batch
+    {backspace}type: io.kestra.core.tasks.scripts.Bash
+commands:
+- echo "Starting batch process..."{enter}
+{backspace}{backspace}{backspace}
+triggers:
+- id: trigger
+    {backspace}type: io.kestra.plugin.jdbc.sqlserver.Trigger{enter}
+logLevel: WARN{enter}
+url: "{{}{{} secret('db.erp.jdbc_uri') }}"
+username: "{{}{{} secret('db.erp.username') }}"
+password: "{{}{{} secret('db.erp.password') }}"
+sql: >
+ SELECT TOP(1) 
+FROM fL_PLMS_PN_STYL_SIZE_SKU_RCV_M
+WHERE TSK_PRCS_YN = 'N'
+ORDER BY ModifIedAt
+{backspace}fetchType: FETCH{enter}
+fetchSize: 100{enter}
+{backspace}- id: schedule
+    {backspace}type: io.kestra.plugin.core.trigger.Schedule{enter}
+cron: "@hourly"`);
+cy.get('span.mtk22').first().click().type('{ctrl}', {release:false}).type('s');
+cy.wait(2000);
+if (cy.get('div.el-message-box').should('be.visible')) {
+    cy.get('span').contains('OK').click();
+}
+cy.wait(2500);
+cy.visit("http://localhost:5173/admin/triggers");
+cy.get('span.caret-wrapper').eq(1).click();
+cy.wait(1000);
+cy.get('div.trigger').first().click();
+cy.get('div[aria-label="Trigger details: trigger"]').should('be.visible');
+cy.get('div.trigger').eq(1).click();
+cy.get('div[aria-label="Trigger details: schedule"]').should('be.visible');
+    });
+});

--- a/ui/src/components/admin/Triggers.vue
+++ b/ui/src/components/admin/Triggers.vue
@@ -158,6 +158,14 @@
                                 <date-ago :inverted="true" :date="scope.row.nextExecutionDate" />
                             </template>
                         </el-table-column>
+                        <el-table-column :label="$t('Information')">
+                            <template #default="scope">
+                                <TriggerAvatar
+                                    :trigger-id="scope.row.id"
+                                    :flow="{flowId: scope.row.flowId, namespace: scope.row.namespace, triggers: [scope.row]}"
+                                />
+                            </template>
+                        </el-table-column>
                         <el-table-column :label="$t('evaluation lock date')">
                             <template #default="scope">
                                 <date-ago :inverted="true" :date="scope.row.evaluateRunningDate" />
@@ -258,6 +266,7 @@
     import SelectTable from "../layout/SelectTable.vue";
     import BulkSelect from "../layout/BulkSelect.vue";
     import Restart from "vue-material-design-icons/Restart.vue";
+    import TriggerAvatar from "../flows/TriggerAvatar.vue";
 </script>
 <script>
     import NamespaceSelect from "../namespace/NamespaceSelect.vue";


### PR DESCRIPTION
### What changes are being made and why?

Closes issue [#5568](https://github.com/kestra-io/kestra/issues/5568). Adds a trigger avatar under triggers page in admin section providing user with additional trigger information upon hover.

<!-- Please include a brief summary of the changes included in this PR e.g. closes #1234. -->

---

### Screenshots
- Before:
![before](https://github.com/user-attachments/assets/161a7707-d912-422d-b4db-c03c67c72484)
- After:
![After](https://github.com/user-attachments/assets/61d20f90-cbe7-415c-85a1-cff352a27f68)

---

---
### Test Cases:
- Triggers Trigger Check
![Triggers Trigger Check](https://github.com/user-attachments/assets/d01e2dfa-cb7e-46eb-8bbd-9bb0cce25eff)
- Triggers Schedule Check
![Triggers Schedule Check](https://github.com/user-attachments/assets/742193f8-b9b9-4a95-a05b-c7dd62d93df4)

### Testing Instructions

1. Run docker-compose up
2. Run npm run dev
3. Run npx cypress open
4. Select E2E Testing
5. Click Start E2E Testing in preferred browser
6. Click triggersAdminInfo.cy.js
7. Observe test cases
